### PR TITLE
ui/dialogs.d: fix build error due to missing 'sort'

### DIFF
--- a/src/ui/dialogs.d
+++ b/src/ui/dialogs.d
@@ -12,6 +12,7 @@ private import ct.base;
 import ui.help;
 import ui.ui;
 import ui.input;
+import std.algorithm;
 import std.string;
 import std.file;
 import std.utf;


### PR DESCRIPTION
This error occurs on Linux with ldc and dmd.

src/ui/dialogs.d(411): Error: no property 'sort' for type 'char[][]'