### PR TITLE
Makefile.{dmd,ldc}: Pin C standard to C99

### DIFF
--- a/Makefile.dmd
+++ b/Makefile.dmd
@@ -3,7 +3,7 @@ COMFLAGS=
 DLINK=$(COMFLAGS) 
 VERSION=$(shell cat Version)
 DFLAGS=$(COMFLAGS) -I./src -J./src/c64 -J./src/font -O
-CFLAGS=$(COMFLAGS) -O1
+CFLAGS=$(COMFLAGS) -O1 -std=c99
 CXXFLAGS=-I./src -O3
 COMPILE.d = $(DC) $(DFLAGS) -c -of$@
 OUTPUT_OPTION=
@@ -21,7 +21,7 @@ $(TARGET): $(C64OBJS) $(OBJS) $(CXX_OBJS)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 .c.o : $(C_SRCS)
-	$(CC) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 ct: $(C64OBJS) $(CTOBJS)
 

--- a/Makefile.ldc
+++ b/Makefile.ldc
@@ -6,7 +6,7 @@ LIBS=-L-ldl -L-lstdc++
 COMFLAGS=-O2
 VERSION=$(shell cat Version)
 DFLAGS=$(COMFLAGS) -I./src -J./src/c64 -J./src/font
-CFLAGS=$(COMFLAGS)
+CFLAGS=$(COMFLAGS) -std=c99
 CXXFLAGS=$(COMFLAGS) -I./src 
 COMPILE.d = $(DC) $(DFLAGS) -c
 DC=ldc2
@@ -28,7 +28,7 @@ ccutter:$(C64OBJS) $(OBJS) $(CXX_OBJS)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 .c.o : $(C_SRCS)
-	$(CC) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 ct: $(C64OBJS) $(CTOBJS)
 


### PR DESCRIPTION
Code is definitely not C23-compatible, and I imagine C99 is *prolly* what this was initially targeting.

https://hydra.nixos.org/build/317828012

```
gcc -c src/asm/acme.c -o src/asm/acme.o
In file included from src/asm/acme.h:10,
                 from src/asm/acme.c:31:
src/asm/config.h:53:17: error: 'bool' cannot be defined via 'typedef'
   53 | typedef int     bool;
      |                 ^~~~
src/asm/config.h:53:17: note: 'bool' is a keyword with '-std=c23' onwards
src/asm/config.h:53:1: warning: useless type name in empty declaration
   53 | typedef int     bool;
      | ^~~~~~~
src/asm/acme.c: In function 'acme_assemble':
src/asm/acme.c:157:32: error: too many arguments to function 'Output_get_final_data'; expected 0, have 1
  157 |                         return Output_get_final_data(length);
      |                                ^~~~~~~~~~~~~~~~~~~~~ ~~~~~~
In file included from src/asm/acme.c:44:
src/asm/output.h:43:14: note: declared here
   43 | extern char* Output_get_final_data();
      |              ^~~~~~~~~~~~~~~~~~~~~
```

The other Makefiles prolly have this issue too, but the LDC one is the only one we're really using downstream in Nixpkgs.